### PR TITLE
Keyword Updates for OBSERVER and ROTSERVO

### DIFF
--- a/KOA_DEIMOS_Keyword_Table.txt
+++ b/KOA_DEIMOS_Keyword_Table.txt
@@ -243,7 +243,7 @@ NAXIS	NAXIS	DEIMOS	integer		NUMBER(*,0)	16	Y	Y	N		11d					Y			Y		naxis
 NSUBINT	NSUBINT	DEIMOS	integer		NUMBER(*,0)	16	Y	Y	N		11d					Y			Y		number of sub integrations		
 NVIDINP	NVIDINP	DEIMOS	integer		NUMBER(*,0)	16	Y	Y	N		11d					Y			Y		number of video inputs		
 OBJECT	OBJECT	DEIMOS	char		VARCHAR2(72 BYTE)	72	Y	Y	N		72s					Y			Y		object		
-OBSERVER	OBSERVER	DEIMOS	char		VARCHAR2(72 BYTE)	72	Y	Y	N		72s					Y			Y		observer		
+OBSERVER	OBSERVER	DEIMOS	char		VARCHAR2(128 BYTE)	128	Y	Y	N		128s					Y			Y		observer		
 OBSTYPE	OBSTYPE	DEIMOS	char		VARCHAR2(16 BYTE)	16	Y	Y	N		16s					Y			Y		observation type		
 OUTDIR	OUTDIR	DEIMOS	char		VARCHAR2(72 BYTE)	72	Y	Y	N		72s					Y			Y		data output directory		
 OUTFILE	OUTFILE	DEIMOS	char		VARCHAR2(16 BYTE)	16	Y	Y	N		16s					Y			Y		output file		

--- a/KOA_ESI_Keyword_Table.txt
+++ b/KOA_ESI_Keyword_Table.txt
@@ -165,7 +165,7 @@ NAXIS2	NAXIS2	ESI	integer		NUMBER(*,0)	16	Y	Y	N		11d					Y					Length of data ax
 NSUBINT	NSUBINT	ESI	integer		NUMBER(*,0)	8	Y	Y	N		11d					Y					number of sub integrations		
 NUMAMPS	NUMAMPS	ESI	integer		NUMBER(*,0)	8	Y	Y	N		11d					Y					number of amplifiers		
 OBJECT	OBJECT	ESI	char		VARCHAR2(72 BYTE)	72	Y	Y	N		72s					Y	Y			Y	object	sky, G93-48 B	
-OBSERVER	OBSERVER	ESI	char		VARCHAR2(72 BYTE)	72	Y	Y	N		72s					Y					observer		
+OBSERVER	OBSERVER	ESI	char		VARCHAR2(128 BYTE)	128	Y	Y	N		128s					Y					observer		
 OBSNUM	OBSNUM	ESI	integer		NUMBER(*,0)	8	Y	Y	N		11d					Y					observation number		
 OBSTYPE	OBSTYPE	ESI	char		VARCHAR2(32 BYTE)	32	Y	Y	N		32s					Y					observation type		
 OUTDIR	OUTDIR	ESI	char		VARCHAR2(72 BYTE)	72	Y	Y	N		72s					Y					data output directory		

--- a/KOA_HIRES_Keyword_Table.txt
+++ b/KOA_HIRES_Keyword_Table.txt
@@ -194,7 +194,7 @@ NUMAMPS	NUMAMPS		integer		NUMBER(*,0)	16	Y	Y	N		16d		1	16					Y	N	number-of-read
 NVIDINP	NVIDINP		integer		NUMBER(*,0)	16	Y	Y	Y		16d		1	16					Y	Y	number of video inputs		
 OA	OA		char		VARCHAR2(69 BYTE)	68	Y	N	N		68s								Y	N	observing assistant		
 OBJECT	OBJECT		char		VARCHAR2(69 BYTE)	68	Y	N	N		68s								Y	Y	object name		
-OBSERVER	OBSERVER		char		VARCHAR2(69 BYTE)	68	Y	N	N		68s								Y	N	observer name		
+OBSERVER	OBSERVER		char		VARCHAR2(128 BYTE)	128	Y	N	N		128s								Y	N	observer name		
 OBSNUM	OBSNUM		integer		NUMBER(*,0)	16	Y	Y	N		16d								Y	N	observation number		
 OBSTYPE	OBSTYPE		char		VARCHAR2(69 BYTE)	68	Y	N	N		68s								Y	N	type of observation		
 OUTDIR	OUTDIR		char		VARCHAR2(69 BYTE)	68	Y	N	N		68s								Y	N	readout-directory		

--- a/KOA_KCWI_Keyword_Table.txt
+++ b/KOA_KCWI_Keyword_Table.txt
@@ -367,7 +367,7 @@ NUMOPEN	NUMOPEN	KCWI	integer		NUMBER(*,0)	16	Y	Y	N		16d					Y					number of shut
 NVIDINP	NVIDINP	KCWI	integer		NUMBER(*,0)	16	Y	Y	N		16d					Y					number of active video inputs	4	
 OA	OA	KOA	char		VARCHAR2(32 BYTE)	32	Y	Y	N		32s					Y					Observing assistant		
 OBJECT	OBJECT	KCWI	char		VARCHAR2(68 BYTE)	68	Y	Y	N		68s					Y	Y				Object name	centering	
-OBSERVER	OBSERVER	KCWI	char		VARCHAR2(68 BYTE)	68	Y	Y	N		68s					Y					Observer name	matmat	
+OBSERVER	OBSERVER	KCWI	char		VARCHAR2(128 BYTE)	128	Y	Y	N		128s					Y					Observer name	matmat	
 OFNAME	OFNAME	KCWI	char		VARCHAR2(32 BYTE)	32	N	Y	N		32s					Y	Y				original file name	kcwi19190.fits	Is 15 characters enough for these? -[ACL]  Column G has correct value.  Column F has been updated
 OMICPIX1	OMICPIX1	KCWI	integer	units	NUMBER(*,0)	8	Y	Y	N		8d					Y					[CCDpix] overscan mixed with image pixels	0	
 OMICPIX2	OMICPIX2	KCWI	integer	units	NUMBER(*,0)	8	Y	Y	N		8d					Y					[CCDpix] overscan mixed with image pixels	0	

--- a/KOA_LRIS_Keyword_Table.txt
+++ b/KOA_LRIS_Keyword_Table.txt
@@ -237,7 +237,7 @@ NUMOPEN	NUMOPEN	LRIS	integer		NUMBER(*,0)	8	Y	N	N		8d					Y					number of shutte
 NVIDINP	NVIDINP	LRIS	integer		NUMBER(*,0)	16	Y	Y	N		16d					Y	Y	Y	Y	Y	Number of video inputs	4	
 OA	OA	KOA	char		VARCHAR2(32 BYTE)	32	Y	Y	N		32s					Y			Y		Observing assistant		
 OBJECT	OBJECT	LRIS	char		VARCHAR2(70 BYTE)	70	Y	Y	N		70s					Y	Y		Y	Y	Object's name	NGC 4889	
-OBSERVER	OBSERVER	LRIS	char		VARCHAR2(70 BYTE)	70	Y	Y	N		70s					Y			Y		Observer's name(s)	McConnell	
+OBSERVER	OBSERVER	LRIS	char		VARCHAR2(128 BYTE)	128	Y	Y	N		128s					Y			Y		Observer's name(s)	McConnell	
 OBSMODE	OBSMODE	KOA,LRIS	char		VARCHAR2(16 BYTE)	16	Y	Y	Y		16s				IMAGING, SPEC, Imaging, Spectroscopy	Y	Y		Y	Y	Imaging or Spec mode		
 OBSTYPE	OBSTYPE	LRIS	char		VARCHAR2(32 BYTE)	32	Y	Y	N		32s					Y			Y		Type of observation	dark	
 OFNAME	OFNAME	LRIS	char		VARCHAR2(32 BYTE)	32	Y	N	N		32s					Y					original file name	r210729_00005.fits	

--- a/KOA_MOSFIRE_Keyword_Table.txt
+++ b/KOA_MOSFIRE_Keyword_Table.txt
@@ -192,7 +192,7 @@ NAXIS2	NAXIS2	MOSFIRE	integer		NUMBER(*,0)	16	Y	Y	N		16d					Y			Y		length of da
 NPIXSAT	NPIXSAT	KOA	integer		NUMBER(*,0)	16	N	Y	N		16d					Y			Y		Number of pixels above saturation		
 NUMREADS	NUMREADS	MOSFIRE	integer		NUMBER(*,0)	8	Y	Y	N		8d					Y			Y	Y	Number of reads		
 OA	OA	KOA	char		VARCHAR2(32 BYTE)	32	Y	Y	N		32s					Y			Y		Observing assistant		
-OBSERVER	OBSERVER	MOSFIRE	char		VARCHAR2(68 BYTE)	68	Y	Y	N		68s					Y			Y		Observer name(s)		
+OBSERVER	OBSERVER	MOSFIRE	char		VARCHAR2(128 BYTE)	128	Y	Y	N		128s					Y			Y		Observer name(s)		
 OUTDIR	OUTDIR	MOSFIRE	char		VARCHAR2(68 BYTE)	68	Y	Y	N		68s					Y			Y		Output directory		
 OUTPTMP1	OUTPTMP1	MOSFIRE	double		FLOAT(126)	24	Y	Y	N		18.8f					Y			Y		Ch A heater output percentage		
 OUTPTMP2	OUTPTMP2	MOSFIRE	double		FLOAT(126)	24	Y	Y	N		18.8f					Y			Y		Ch B heater output percentage		

--- a/KOA_NIRC2_Keyword_Table.txt
+++ b/KOA_NIRC2_Keyword_Table.txt
@@ -286,7 +286,7 @@ OBLBY	OBLBY		double		FLOAT(126)	16	Y	Y	N		18.5f					Y					[mm] User-value-of-LBS
 OBRT	OBRT	ao	double	degrees	FLOAT(126)	20	Y	Y	N		18.8f					Y					User value of ROT 		
 OBRTNAME	OBRTNAME	ao-legacy	char		VARCHAR2(20 BYTE)	20	Y	Y	N		20s					Y					Named position control for ROT		
 OBSDNAME	OBSDNAME	ao	char		VARCHAR2(20 BYTE)	20	Y	Y	N		20s					Y					Named position control for SOD		
-OBSERVER	OBSERVER	alad	char		VARCHAR2(72 BYTE)	72	Y	Y	N		72s					Y					Observer		
+OBSERVER	OBSERVER	alad	char		VARCHAR2(128 BYTE)	128	Y	Y	N		128s					Y					Observer		
 OBSFNAME	OBSFNAME	ao	char		VARCHAR2(20 BYTE)	20	Y	Y	N		20s					Y					Named position control for SFP		
 OBSFX	OBSFX	ao	double	mm	FLOAT(126)	20	Y	Y	N		18.8f					Y					User value of SFP x axis 		
 OBSFY	OBSFY	ao	double	mm	FLOAT(126)	20	Y	Y	N		18.8f					Y					User value of SFP y axis		
@@ -457,7 +457,7 @@ ROTPOSN	ROTPOSN	dcs	double	degrees	FLOAT(126)	20	Y	Y	N		18.8f					Y					rotator 
 ROTPPOSN	ROTPPOSN	dcs	double	degrees	FLOAT(126)	20	Y	Y	N		18.8f					Y					rotator physical position 		
 ROTPRIOD	ROTPRIOD	nirc2	double	degrees	FLOAT(126)	16	Y	Y	N		18.8f					Y					 Pupil mask rotato servo period		
 ROTREFAN	ROTREFAN	dcs	double	degrees	FLOAT(126)	20	Y	Y	N		18.8f					Y					rotator reference angle		
-ROTSERVO	ROTSERVO		integer		NUMBER(38)	8	Y	Y	N		8d					Y					Pupil mask rotator servo start cmd		
+ROTSERVO	ROTSERVO		integer		NUMBER(16)	16	Y	Y	N		16d					Y					Pupil mask rotator servo start cmd		
 ROTSEL	ROTSEL		char		VARCHAR2(32 BYTE)	32	Y	Y	N		32s					Y					DCS Selected rotator	none	
 ROTSTST	ROTSTST		char		VARCHAR2(16 BYTE)	16	Y	Y	N		16s					Y					DCS Rotator state string	FAULT	
 ROTTRACK	ROTTRACK		char		VARCHAR2(16 BYTE)	16	Y	Y	N		16s					Y					Pupil mask rotator tracking command		

--- a/KOA_NIRES_Keyword_Table.txt
+++ b/KOA_NIRES_Keyword_Table.txt
@@ -107,7 +107,7 @@ NUMREADS	NUMREADS	NIRES	integer		INTEGER	16	Y	Y	N		11d					Y			Y		Number of read
 NUMUTRS	NUMUTRS	NIRES	integer		INTEGER	16	Y	Y	N		11d					Y			Y		SDSU NUTR value	1	
 OA	OA	KOA	char		VARCHAR2(32 BYTE)	32	Y	Y	N		32s					Y			Y		Observing assistant		
 OBJECT	OBJECT	NIRES	char		VARCHAR2(68 BYTE)	68	Y	Y	N		68s					Y	Y		Y		Object name	MIRA sky	
-OBSERVER	OBSERVER	NIRES	char		VARCHAR2(68)	68	Y	Y	N		68s					Y			Y		Observer name(s BYTE)	Matthews/Cromer	
+OBSERVER	OBSERVER	NIRES	char		VARCHAR2(128 BYTE)	128	Y	Y	N		128s					Y			Y		Observer name(s BYTE)	Matthews/Cromer	
 OBSTYPE	OBSTYPE	NIRES	char		VARCHAR2(32 BYTE)	32	Y	Y	N		32s					Y			Y		Observation type	astro	What are allowed values?
 OFNAME	OFNAME	KOA	char		VARCHAR2(32 BYTE)	32	Y	Y	N		32s					Y			Y		Original file name at the telescope, copied from DATAFILE keyword	v171005_0001	
 OUTDIR	OUTDIR	NIRES	char		VARCHAR2(68 BYTE)	68	Y	Y	N		68s					Y			Y		Original output directory		

--- a/KOA_NIRSPEC_Keyword_Table.txt
+++ b/KOA_NIRSPEC_Keyword_Table.txt
@@ -219,7 +219,7 @@ OBLBX	OBLBX	Native	double	mm	FLOAT(126)	32	Y	Y	N		18.8f										User-value-of-L
 OBLBY	OBLBY	Native	double	mm	FLOAT(126)	32	Y	Y	N		18.8f										User-value-of-LBS-y-axis		
 OBRT	OBRT	Native	double	degrees	FLOAT(126)	32	Y	Y	N		18.8f										User value of ROT (31.4380 deg)		
 OBSDNAME	OBSDNAME	Native	char		VARCHAR2(24 BYTE)	24	Y	Y	N		24s										Named position control for SOD		
-OBSERVER	OBSERVER	Native	char		VARCHAR2(72 BYTE)	72	Y	Y	N		72s										Observer		
+OBSERVER	OBSERVER	Native	char		VARCHAR2(128 BYTE)	128	Y	Y	N		128s										Observer		
 OBSFNAME	OBSFNAME	Native	char		VARCHAR2(24 BYTE)	24	Y	Y	N		24s										Named position control for SFP		
 OBSFX	OBSFX	Native	double	mm	FLOAT(126)	32	Y	Y	N		18.8f										User value of SFP x axis (-119.00 mm)		
 OBSFY	OBSFY	Native	double	mm	FLOAT(126)	32	Y	Y	N		18.8f										User value of SFP y axis (0.00 mm)		

--- a/KOA_OSIRIS_Keyword_Table.txt
+++ b/KOA_OSIRIS_Keyword_Table.txt
@@ -252,7 +252,7 @@ OBLBX	OBLBX		double		FLOAT(126)	16	Y	Y	N		18.5f					Y					User value of LBS x ax
 OBLBY	OBLBY		double		FLOAT(126)	16	Y	Y	N		18.5f					Y					User value of LBS y axis (mm)	-0.53
 OBRT	OBRT		double		FLOAT(126)	17	Y	Y	N		18.5f					Y					User value of ROT (deg)g
 OBSDNAME	OBSDNAME		char		VARCHAR2(25 BYTE)	25	Y	Y	N		25s					Y					Named position control for SODg
-OBSERVER	OBSERVER		char		VARCHAR2(60 BYTE)	60	Y	Y	N		60s					Y					Observer name(s)g
+OBSERVER	OBSERVER		char		VARCHAR2(128 BYTE)	128	Y	Y	N		128s					Y					Observer name(s)g
 OBSFNAME	OBSFNAME		char		VARCHAR2(25 BYTE)	25	Y	Y	N		25s					Y					Named position control for SFPg
 OBSFX	OBSFX		double	mm	FLOAT(126)	17	Y	Y	N		18.5f					Y					User value of SFP x axis (mm)g
 OBSFY	OBSFY		double	mm	FLOAT(126)	14	Y	Y	N		18.5f					Y					User value of SFP y axis (mm)g


### PR DESCRIPTION
Increase OBSERVER keyword max chars from various to 128: HIRES,LRIS,MOSFIRE,OSIRIS,DEIMOS,ESI,KCWI,NIRC2,NIRES,NIRSPEC (KPF already done)

Increase ROTSERVO keyword max chars from 8 to 16: NIRC2